### PR TITLE
feat: add support for format-jinja and format-jinja-imports

### DIFF
--- a/docs/version_source.md
+++ b/docs/version_source.md
@@ -31,7 +31,7 @@ dynamic = ["version"]
 
 > [!NOTE]
 >
-> - Configuration is almost same to [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning). But `format-jinja`, `format-jinja-imports` are not supported.
+> - Configuration is almost same to [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning). But `format-jinja-imports` is not supported.
 > - The following descriptions are excerpts from [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning).
 
 In your `pyproject.toml`, you may configure the following options:
@@ -103,6 +103,27 @@ In your `pyproject.toml`, you may configure the following options:
     - `{timestamp}` of the current commit, which expands to YYYYmmddHHMMSS as UTC
 
     Example: `v{base}+{distance}.{commit}`
+
+  - `format-jinja` (string, default: empty):
+    Jinja2 template for version formatting. Available variables:
+    - `base`: Base version (e.g., "1.0.0")
+    - `stage`: Stage (e.g., "alpha", "beta", "rc")
+    - `revision`: Revision number
+    - `distance`: Number of commits since last tag
+    - `commit`: Commit hash
+    - `dirty`: Boolean indicating if working directory is dirty
+    - `branch`: Current branch name
+    - `tagged_metadata`: Metadata from tag
+    - `branch_escaped`: Branch name with special characters removed
+    - `timestamp`: Timestamp of the commit
+    - `major`: Major version number
+    - `minor`: Minor version number
+    - `patch`: Patch version number
+    - `env`: Environment variables
+    - `bump_version`: Function to bump version
+    - `serialize_pep440`: Function to serialize version in PEP 440 format
+    - `serialize_pvp`: Function to serialize version in PVP format
+    - `serialize_semver`: Function to serialize version in SemVer format
 
   - `style` (string, default: unset):
     One of: `pep440`, `semver`, `pvp`.

--- a/src/uv_dynamic_versioning/jinja.py
+++ b/src/uv_dynamic_versioning/jinja.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+from datetime import datetime
+from typing import Callable
+
+import jinja2
+from dunamai import (
+    Version,
+    bump_version,
+    serialize_pep440,
+    serialize_pvp,
+    serialize_semver,
+)
+from pydantic import BaseModel, ConfigDict, Field
+
+from . import schemas
+
+
+def render_jinja(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+) -> str:
+    if config.bump and version.distance > 0:
+        version = version.bump(smart=True)
+
+    default_context = _JinjaDefaultContext.from_version(version).model_dump()
+
+    return jinja2.Template(config.format_jinja).render(**default_context)
+
+
+class _JinjaDefaultContext(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    version: Version
+    base: str | None = Field(default=None)
+    stage: str | None = Field(default=None)
+    revision: int | None = Field(default=None)
+    distance: int | None = Field(default=None)
+    commit: str | None = Field(default=None)
+    dirty: bool | None = Field(default=None)
+    branch: str | None = Field(default=None)
+    tagged_metadata: str | None = Field(default=None)
+    branch_escaped: str | None = Field(default=None)
+    timestamp: str | None = Field(default=None)
+    major: int | None = Field(default=None)
+    minor: int | None = Field(default=None)
+    patch: int | None = Field(default=None)
+    env: os._Environ[str] = Field(default=os.environ)
+    bump_version: Callable[[Version, bool], Version] = Field(default=bump_version)
+    serialize_pep440: Callable[[Version], str] = Field(default=serialize_pep440)
+    serialize_pvp: Callable[[Version], str] = Field(default=serialize_pvp)
+    serialize_semver: Callable[[Version], str] = Field(default=serialize_semver)
+
+    @classmethod
+    def from_version(cls, version: Version) -> _JinjaDefaultContext:
+        return cls(
+            version=version,
+            base=version.base,
+            stage=version.stage,
+            revision=version.revision,
+            distance=version.distance,
+            commit=version.commit,
+            dirty=version.dirty,
+            branch=version.branch,
+            tagged_metadata=version.tagged_metadata,
+            branch_escaped=_escape_branch(version.branch),
+            timestamp=_format_timestamp(version.timestamp),
+            major=_base_part(version.base, 0),
+            minor=_base_part(version.base, 1),
+            patch=_base_part(version.base, 2),
+        )
+
+
+def _base_part(base: str, index: int) -> int:
+    parts = base.split(".")
+    result = 0
+
+    with contextlib.suppress(KeyError, ValueError):
+        result = int(parts[index])
+
+    return result
+
+
+def _escape_branch(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return re.sub(r"[^a-zA-Z0-9]", "", value)
+
+
+def _format_timestamp(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+
+    return value.strftime("%Y%m%d%H%M%S")

--- a/src/uv_dynamic_versioning/main.py
+++ b/src/uv_dynamic_versioning/main.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import tomlkit
 from dunamai import Version
 
+from uv_dynamic_versioning.jinja import render_jinja
+
 from . import schemas
 
 
@@ -35,6 +37,9 @@ def get_version(config: schemas.UvDynamicVersioning) -> str:
         pattern=config.pattern,
         pattern_prefix=config.pattern_prefix,
     )
+
+    if config.format_jinja:
+        return render_jinja(version, config)
 
     return version.serialize(
         metadata=config.metadata,

--- a/src/uv_dynamic_versioning/schemas.py
+++ b/src/uv_dynamic_versioning/schemas.py
@@ -12,6 +12,7 @@ class UvDynamicVersioning(BaseModel):
     pattern: Pattern = Pattern.Default
     pattern_prefix: str | None = Field(default=None, alias="pattern-prefix")
     format: str | None = None
+    format_jinja: str | None = Field(default=None, alias="format-jinja")
     style: Style | None = None
     latest_tag: bool = False
     strict: bool = False

--- a/tests/fixtures/with-jinja-format/pyproject.toml
+++ b/tests/fixtures/with-jinja-format/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "dummy"
+version = "0.1.0"
+description = ""
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv-dynamic-versioning]
+format-jinja = """{{- base }}.dev{{ distance }}+g{{commit}}"""

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timezone
+
+import pytest
+from dunamai import Version
+
+from uv_dynamic_versioning import jinja, schemas
+
+
+@pytest.fixture
+def version():
+    return Version(
+        base="1.0.0",
+        stage=("alpha", 1),
+        distance=0,
+        commit="message",
+        dirty=False,
+        branch="main",
+        timestamp=datetime(2025, 4, 1, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def config():
+    return schemas.UvDynamicVersioning.model_validate(
+        {
+            "format-jinja": "{{- base }}",
+        }
+    )
+
+
+def test_when_rendering_basic_version_then_returns_base_version(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    result = jinja.render_jinja(version, config)
+
+    assert result == "1.0.0"
+
+
+def test_when_bumping_version_then_returns_bumped_version(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    version.distance = 2
+    version.revision = 1
+    config.bump = True
+    config.format_jinja = "{{- base }}+r{{- revision }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "1.0.0+r2"
+
+
+def test_when_rendering_version_with_stage_and_revision_then_returns_formatted_version(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    config.format_jinja = "{{- base }}{{- stage }}{{- revision }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "1.0.0alpha1"
+
+
+def test_when_rendering_version_with_commit_and_branch_then_returns_formatted_version(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    config.format_jinja = "{{- commit }}-{{- branch }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "message-main"
+
+
+def test_when_rendering_version_with_timestamp_then_returns_formatted_timestamp(
+    version: Version, config: schemas.UvDynamicVersioning
+):
+    config.format_jinja = "{{- timestamp }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "20250401120000"
+
+
+def test_when_rendering_version_with_individual_parts_then_returns_formatted_version(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    config.format_jinja = "{{- major }}.{{- minor }}.{{- patch }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "1.0.0"
+
+
+def test_when_rendering_version_with_escaped_branch_then_returns_escaped_branch(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    version.branch = "feature/new-branch"
+    config.format_jinja = "{{- branch_escaped }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "featurenewbranch"
+
+
+def test_when_rendering_version_with_dirty_flag_then_returns_dirty_status(
+    version: Version, config: schemas.UvDynamicVersioning
+):
+    version.dirty = True
+    config.format_jinja = "{{- 'dirty' if dirty else 'clean' }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "dirty"
+
+
+def test_when_rendering_version_with_environment_variables_then_returns_env_value(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("TEST_VAR", "test_value")
+    config.format_jinja = "{{ env.TEST_VAR }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "test_value"
+
+
+def test_when_rendering_version_with_serialization_functions_then_returns_serialized_version(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    config.format_jinja = "{{ serialize_pep440(base, stage, revision) }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "1.0.0a1"
+
+
+def test_when_rendering_version_with_serialization_functions_and_bump_then_returns_bumped_serialized_version(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    config.format_jinja = "{{ serialize_pep440(bump_version(base), stage, revision) }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "1.0.1a1"
+
+
+def test_when_rendering_version_with_tagged_metadata_then_returns_metadata(
+    version: Version,
+    config: schemas.UvDynamicVersioning,
+):
+    version.tagged_metadata = "build123"
+    config.format_jinja = "{{ tagged_metadata }}"
+
+    result = jinja.render_jinja(version, config)
+
+    assert result == "build123"

--- a/tests/test_version_source.py
+++ b/tests/test_version_source.py
@@ -1,48 +1,56 @@
+from collections.abc import Generator
 from unittest.mock import PropertyMock, patch
 
+import pytest
 from git import Repo, TagReference
 
 from uv_dynamic_versioning.version_source import DynamicVersionSource
 
 
-def test_with_semver(semver_tag: TagReference):
-    source = DynamicVersionSource(str(semver_tag.repo.working_dir), {})
-
+@pytest.fixture
+def mock_root() -> Generator[PropertyMock, None, None]:
     with patch(
         "uv_dynamic_versioning.version_source.DynamicVersionSource.root",
         new_callable=PropertyMock,
-    ) as mock_root:
-        mock_root.return_value = "tests/fixtures/with-semver/"
-
-        version = source.get_version_data()["version"]
-        assert version == "1.0.0"
+    ) as mock:
+        yield mock
 
 
-def test_with_format(semver_tag: TagReference):
+def test_with_semver(semver_tag: TagReference, mock_root: PropertyMock):
     source = DynamicVersionSource(str(semver_tag.repo.working_dir), {})
+    mock_root.return_value = "tests/fixtures/with-semver/"
 
-    with patch(
-        "uv_dynamic_versioning.version_source.DynamicVersionSource.root",
-        new_callable=PropertyMock,
-    ) as mock_root:
-        mock_root.return_value = "tests/fixtures/with-format/"
+    version = source.get_version_data()["version"]
 
-        version: str = source.get_version_data()["version"]
-        assert version.startswith("v1.0.0+")
+    assert version == "1.0.0"
 
 
-def test_with_bump(repo: Repo, semver_tag: TagReference):
+def test_with_format(semver_tag: TagReference, mock_root: PropertyMock):
     source = DynamicVersionSource(str(semver_tag.repo.working_dir), {})
+    mock_root.return_value = "tests/fixtures/with-format/"
 
+    version: str = source.get_version_data()["version"]
+
+    assert version.startswith("v1.0.0+")
+
+
+def test_with_bump(repo: Repo, semver_tag: TagReference, mock_root: PropertyMock):
+    source = DynamicVersionSource(str(semver_tag.repo.working_dir), {})
+    mock_root.return_value = "tests/fixtures/with-bump/"
     repo.git.execute(["git", "commit", "--allow-empty", "-m", "empty commit"])
-    try:
-        with patch(
-            "uv_dynamic_versioning.version_source.DynamicVersionSource.root",
-            new_callable=PropertyMock,
-        ) as mock_root:
-            mock_root.return_value = "tests/fixtures/with-bump/"
 
-            version: str = source.get_version_data()["version"]
-            assert version.startswith("1.0.1.")
+    try:
+        version: str = source.get_version_data()["version"]
+
+        assert version.startswith("1.0.1.")
     finally:
         repo.git.execute(["git", "reset", "--soft", "HEAD~1"])
+
+
+def test_with_jinja2_format(semver_tag: TagReference, mock_root: PropertyMock):
+    source = DynamicVersionSource(str(semver_tag.repo.working_dir), {})
+    mock_root.return_value = "tests/fixtures/with-jinja-format/"
+
+    version: str = source.get_version_data()["version"]
+
+    assert version.startswith("1.0.0.dev0+g")


### PR DESCRIPTION
Hi @ninoseki,

This PR adds support for Jinja2 templating in version formatting by introducing two new configuration options:

`format-jinja` – Enables the use of Jinja2 templates for version formatting, providing access to version variables and helper functions.

`format-jinja-imports` – Allows importing additional modules and their items into the Jinja2 template context for more advanced formatting logic.