### PR TITLE
feat: add fallback-version

### DIFF
--- a/docs/version_source.md
+++ b/docs/version_source.md
@@ -116,6 +116,7 @@ You may configure the following options under `[tool.uv-dynamic-versioning]`:
 - `strict` (boolean, default: false): If true, then fail instead of falling back to 0.0.0 when there are no tags.
 - `ignore-untracked` (boolean, default: false): If true, ignore untracked files when determining whether the repository is dirty.
 - `commit-length` (integer, default: unset): Use this many characters from the start of the full commit hash.
+- `fallback-version` (str, default: unset): Version to be used if an error occurs when obtaining the version, for example, there is no `.git/`. If not specified, unsuccessful version obtaining from vcs will raise an error.
 
 Simple example:
 

--- a/src/uv_dynamic_versioning/main.py
+++ b/src/uv_dynamic_versioning/main.py
@@ -26,18 +26,23 @@ def _get_version(config: schemas.UvDynamicVersioning) -> Version:
     if "UV_DYNAMIC_VERSIONING_BYPASS" in os.environ:
         return Version.parse(os.environ["UV_DYNAMIC_VERSIONING_BYPASS"])
 
-    return Version.from_vcs(
-        config.vcs,
-        latest_tag=config.latest_tag,
-        strict=config.strict,
-        tag_branch=config.tag_branch,
-        tag_dir=config.tag_dir,
-        full_commit=config.full_commit,
-        ignore_untracked=config.ignore_untracked,
-        pattern=config.pattern,
-        pattern_prefix=config.pattern_prefix,
-        commit_length=config.commit_length,
-    )
+    try:
+        return Version.from_vcs(
+            config.vcs,
+            latest_tag=config.latest_tag,
+            strict=config.strict,
+            tag_branch=config.tag_branch,
+            tag_dir=config.tag_dir,
+            full_commit=config.full_commit,
+            ignore_untracked=config.ignore_untracked,
+            pattern=config.pattern,
+            pattern_prefix=config.pattern_prefix,
+            commit_length=config.commit_length,
+        )
+    except RuntimeError as e:
+        if fallback_version := config.fallback_version:
+            return Version(fallback_version)
+        raise e
 
 
 def get_version(config: schemas.UvDynamicVersioning) -> tuple[str, Version]:

--- a/src/uv_dynamic_versioning/schemas.py
+++ b/src/uv_dynamic_versioning/schemas.py
@@ -29,6 +29,7 @@ class UvDynamicVersioning(BaseModel):
     ignore_untracked: bool = Field(default=False, alias="ignore-untracked")
     commit_length: int | None = Field(default=None, alias="commit-length")
     bump: bool | BumpConfig = False
+    fallback_version: str | None = Field(default=None, alias="fallback-version")
 
     @cached_property
     def bump_config(self) -> BumpConfig:


### PR DESCRIPTION
Fix: #27 

---

Test project: <https://github.com/eggplants/uv-dynamic-versioning-fallback-test>

```bash
git clone https://github.com/eggplants/uv-dynamic-versioning-fallback-test
cd uv-dynamic-versioning-fallback-test
```

```shellsession
$ uv build
Building source distribution...
Building wheel from source distribution...
Successfully built dist/uv_dynamic_versioning_fallback_test-0.0.0.post1+2240218.tar.gz
Successfully built dist/uv_dynamic_versioning_fallback_test-0.0.0.post1+2240218-py3-none-any.whl

$ rm -rf .git
$ uv build
Building source distribution...
Building wheel from source distribution...
Successfully built dist/uv_dynamic_versioning_fallback_test-1.2.3.tar.gz
Successfully built dist/uv_dynamic_versioning_fallback_test-1.2.3-py3-none-any.whl

```