### PR TITLE
`UV_DYNAMIC_VERSIONING_BYPASS` bugfix

### DIFF
--- a/src/uv_dynamic_versioning/main.py
+++ b/src/uv_dynamic_versioning/main.py
@@ -23,9 +23,6 @@ def validate(project: tomlkit.TOMLDocument):
 
 
 def _get_version(config: schemas.UvDynamicVersioning) -> Version:
-    if "UV_DYNAMIC_VERSIONING_BYPASS" in os.environ:
-        return Version.parse(os.environ["UV_DYNAMIC_VERSIONING_BYPASS"])
-
     try:
         return Version.from_vcs(
             config.vcs,
@@ -46,6 +43,10 @@ def _get_version(config: schemas.UvDynamicVersioning) -> Version:
 
 
 def get_version(config: schemas.UvDynamicVersioning) -> tuple[str, Version]:
+    version_bypass: str = os.getenv("UV_DYNAMIC_VERSIONING_BYPASS", "")
+    if version_bypass != "":
+        return (version_bypass, Version.parse(version_bypass))
+
     version = _get_version(config)
 
     if config.format_jinja:

--- a/src/uv_dynamic_versioning/main.py
+++ b/src/uv_dynamic_versioning/main.py
@@ -52,7 +52,7 @@ def get_version(config: schemas.UvDynamicVersioning) -> tuple[str, Version]:
         # NOTE: don't know why but poetry-dynamic-versioning check bump_config and also distance when using Jinja2
         #       so follow it
         updated = (
-            version.bump(smart=True, index=config.bump_config.index)
+            version.bump(smart=config.bump_config.smart, index=config.bump_config.index)
             if config.bump_config.enable and version.distance > 0
             else version
         )
@@ -62,7 +62,7 @@ def get_version(config: schemas.UvDynamicVersioning) -> tuple[str, Version]:
         )
 
     updated = (
-        version.bump(smart=True, index=config.bump_config.index)
+        version.bump(smart=config.bump_config.smart, index=config.bump_config.index)
         if config.bump_config.enable
         else version
     )

--- a/src/uv_dynamic_versioning/schemas.py
+++ b/src/uv_dynamic_versioning/schemas.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 class BumpConfig(BaseModel):
     enable: bool = False
     index: int = -1
+    smart: bool = True
 
 
 class UvDynamicVersioning(BaseModel):

--- a/tests/fixtures/with-bump-and-format/pyproject.toml
+++ b/tests/fixtures/with-bump-and-format/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "dummy"
+version = "0.1.0"
+description = ""
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.uv-dynamic-versioning]
+bump = true
+format = """distance: {distance}"""

--- a/tests/test_env_bypass.py
+++ b/tests/test_env_bypass.py
@@ -1,10 +1,23 @@
 import os
+from collections.abc import Generator
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from dunamai import Version
+from git import Repo, TagReference
 
 from uv_dynamic_versioning import schemas
 from uv_dynamic_versioning.main import get_version
+from uv_dynamic_versioning.version_source import DynamicVersionSource
+
+
+@pytest.fixture
+def mock_root() -> Generator[PropertyMock, None, None]:
+    with patch(
+        "uv_dynamic_versioning.version_source.DynamicVersionSource.root",
+        new_callable=PropertyMock,
+    ) as mock:
+        yield mock
 
 
 @pytest.fixture
@@ -22,6 +35,16 @@ def set_uv_dynamic_versioning_bypass(version: str):
         del os.environ["UV_DYNAMIC_VERSIONING_BYPASS"]
 
 
+@pytest.fixture
+def set_uv_dynamic_versioning_bypass_empty(version: str):
+    os.environ["UV_DYNAMIC_VERSIONING_BYPASS"] = ""
+
+    try:
+        yield ""
+    finally:
+        del os.environ["UV_DYNAMIC_VERSIONING_BYPASS"]
+
+
 @pytest.mark.usefixtures("set_uv_dynamic_versioning_bypass")
 def test_get_version(version: str):
     assert get_version(schemas.UvDynamicVersioning()) == (
@@ -32,6 +55,7 @@ def test_get_version(version: str):
 
 @pytest.mark.usefixtures("set_uv_dynamic_versioning_bypass")
 def test_get_version_with_smart_bump(version: str):
+    """Test UV_DYNAMIC_VERSIONING_BYPASS with "smart" version bump enabled"""
     assert get_version(
         schemas.UvDynamicVersioning(bump=schemas.BumpConfig(enable=True, smart=True))
     ) == (
@@ -41,10 +65,51 @@ def test_get_version_with_smart_bump(version: str):
 
 
 @pytest.mark.usefixtures("set_uv_dynamic_versioning_bypass")
-def test_get_version_with_bump(version: str):
+def test_with_bump_and_bypass(
+    repo: Repo, semver_tag: TagReference, mock_root: PropertyMock
+):
+    source = DynamicVersionSource(str(semver_tag.repo.working_dir), {})
+    mock_root.return_value = "tests/fixtures/with-bump/"
+    repo.git.execute(
+        ["git", "commit", "--allow-empty", "-m", "empty commit", "--no-gpg-sign"]
+    )
+
+    try:
+        internal_version: str = source.get_version_data()["version"]
+        assert internal_version.startswith("1.1.1")
+    finally:
+        repo.git.execute(["git", "reset", "--soft", "HEAD~1"])
+
+
+@pytest.mark.usefixtures("set_uv_dynamic_versioning_bypass")
+def test_get_version_with_bump_and_bypass(version: str):
+    """Test UV_DYNAMIC_VERSIONING_BYPASS with guaranteed version bump (not "smart") enabled"""
     assert get_version(
         schemas.UvDynamicVersioning(bump=schemas.BumpConfig(enable=True, smart=False))
     ) == (
         version,
         Version.parse(version),
     )
+
+
+@pytest.mark.usefixtures("set_uv_dynamic_versioning_bypass_empty")
+def test_get_version_with_empty_string_for_bypass(
+    repo: Repo, semver_tag: TagReference, mock_root: PropertyMock, version: str
+):
+    """Verify that UV_DYNAMIC_VERSIONING_BYPASS='' (empty string) is treated as unset and executes get_version() as
+    normal.
+    """
+    source = DynamicVersionSource(str(semver_tag.repo.working_dir), {})
+    mock_root.return_value = "tests/fixtures/with-bump/"
+
+    assert "UV_DYNAMIC_VERSIONING_BYPASS" in os.environ
+
+    repo.git.execute(
+        ["git", "commit", "--allow-empty", "-m", "empty commit", "--no-gpg-sign"]
+    )
+
+    try:
+        internal_version: str = source.get_version_data()["version"]
+        assert internal_version.startswith("1.0.1")
+    finally:
+        repo.git.execute(["git", "reset", "--soft", "HEAD~1"])

--- a/tests/test_env_bypass.py
+++ b/tests/test_env_bypass.py
@@ -28,3 +28,23 @@ def test_get_version(version: str):
         version,
         Version.parse(version),
     )
+
+
+@pytest.mark.usefixtures("set_uv_dynamic_versioning_bypass")
+def test_get_version_with_smart_bump(version: str):
+    assert get_version(
+        schemas.UvDynamicVersioning(bump=schemas.BumpConfig(enable=True, smart=True))
+    ) == (
+        version,
+        Version.parse(version),
+    )
+
+
+@pytest.mark.usefixtures("set_uv_dynamic_versioning_bypass")
+def test_get_version_with_bump(version: str):
+    assert get_version(
+        schemas.UvDynamicVersioning(bump=schemas.BumpConfig(enable=True, smart=False))
+    ) == (
+        version,
+        Version.parse(version),
+    )


### PR DESCRIPTION
* Fix `UV_DYNAMIC_VERSIONING_BYPASS` so that the version parsed from that environment variable is directly returned and not run through the dynamic version logic again
* Treat `UV_DYNAMIC_VERSIONING_BYPASS=""` (empty string) as being unset, since that would make the version parsing logic error anyway
    * also enables setting this variable more dynamically in Conainterfiles with `ENV` and `ARG`
* add tests that fail without this fix in place