### PR TITLE
Add note on uv's build cache

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -23,3 +23,14 @@ A workaround is setting `fallback-version` in the configuration:
 [tool.uv-dynamic-versioning]
 fallback-version = "0.0.0"
 ```
+
+## Build caching and editable installs
+
+The `uv` cache is aggressive, and needs to be made aware that the project's metadata is dynamic, for example like this:
+
+```toml
+[tool.uv]
+cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true }}]
+```
+
+See [`uv`'s docs on dynamic metadata](https://docs.astral.sh/uv/concepts/cache/#dynamic-metadata) for more information.


### PR DESCRIPTION
Ideally I think that the plugin should enable this automatically. I am not sure if there is a way to do that, and this is at least better than nothing.